### PR TITLE
Move tape from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/miguelmota/is-valid-domain/issues"
   },
   "homepage": "https://github.com/miguelmota/is-valid-domain",
-  "dependencies": {
+  "devDependencies": {
     "tape": "^3.0.3"
   },
   "testling": {


### PR DESCRIPTION
Hi! We use this module in some of our code, and we get `npm install` errors because we use tape 4.4, and `is-valid-domain` wants tape 3.0. It won't be an issue if tape is moved to `devDependencies` for your module.

Cheers.