### PR TITLE
Disallow IPv4

### DIFF
--- a/is-valid-domain.js
+++ b/is-valid-domain.js
@@ -12,7 +12,7 @@
     if (!tldRegex.test(tld)) return false
 
     var isValid = parts.every(function(host) {
-      var hostRegex = /^(?!:\/\/)([a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])$/gi;
+      var hostRegex = /^(?!:\/\/|\d)([a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])$/gi;
 
       return hostRegex.test(host)
     })

--- a/test/is-valid-domain.js
+++ b/test/is-valid-domain.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var isValidDomain = require('../is-valid-domain');
 
 test('is valid domain', function (t) {
-  t.plan(28);
+  t.plan(29);
 
   t.equal(isValidDomain('example.com'), true);
   t.equal(isValidDomain('foo.example.com'), true);
@@ -33,4 +33,6 @@ test('is valid domain', function (t) {
   t.equal(isValidDomain('foo.example_.com'), false);
   t.equal(isValidDomain('example.com-'), false);
   t.equal(isValidDomain('example.com_'), false);
+
+  t.equal(isValidDomain('127.0.0.1'), false);
 });


### PR DESCRIPTION
Not sure if still relevant but RFC 1738 Page 5 under 'host' says

> The rightmost domain
        label will never start with a digit, though, which
        syntactically distinguishes all domain names from the IP
        addresses.